### PR TITLE
feat: add real-time 1v1 multiplayer racing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,7 @@
 ## Data Flow
 
 ### 1. Game Start Flow
+
 ```
 User lands on / → Clicks "Race Me" → Redirected to /typer-racer
                                             │
@@ -58,6 +59,7 @@ User lands on / → Clicks "Race Me" → Redirected to /typer-racer
 ```
 
 ### 2. Typing Game Flow
+
 ```
 Corpus loaded from Convex
          │
@@ -77,6 +79,7 @@ Timer hits 0 → Show results + leaderboard
 ```
 
 ### 3. Score Submission Flow
+
 ```
 User clicks Submit
          │
@@ -125,33 +128,36 @@ leaderboard: {
 ## Key Technical Decisions
 
 ### Why Convex over Supabase?
-- Real-time subscriptions out of the box
-- Automatic TypeScript type generation
-- Simpler API for this use case
-- Better developer experience for small projects
+
+-   Real-time subscriptions out of the box
+-   Automatic TypeScript type generation
+-   Simpler API for this use case
+-   Better developer experience for small projects
 
 ### Why Server-Side WPM Validation?
-- Prevents cheating via browser console
-- Validates timing and character counts
-- Rejects impossible scores (>250 WPM)
-- Single source of truth for score calculation
+
+-   Prevents cheating via browser console
+-   Validates timing and character counts
+-   Rejects impossible scores (>250 WPM)
+-   Single source of truth for score calculation
 
 ### Why Custom useTypingGame Hook?
-- Isolates game logic from UI
-- Makes testing easier
-- Reduces component complexity
-- Reusable if adding new game modes
+
+-   Isolates game logic from UI
+-   Makes testing easier
+-   Reduces component complexity
+-   Reusable if adding new game modes
 
 ## Performance Considerations
 
-- Character-by-character rendering optimized with minimal re-renders
-- Left-padding technique keeps current character centered
-- WPM calculated once per second (not per keystroke)
-- Convex subscriptions for real-time leaderboard updates
+-   Character-by-character rendering optimized with minimal re-renders
+-   Left-padding technique keeps current character centered
+-   WPM calculated once per second (not per keystroke)
+-   Convex subscriptions for real-time leaderboard updates
 
 ## Security
 
-- Clerk handles all authentication
-- Server-side score validation prevents manipulation
-- User IDs from Clerk (not client-provided)
-- Protected routes via middleware
+-   Clerk handles all authentication
+-   Server-side score validation prevents manipulation
+-   User IDs from Clerk (not client-provided)
+-   Protected routes via middleware

--- a/README.md
+++ b/README.md
@@ -4,33 +4,33 @@ A real-time typing speed competition app where you race against pre-recorded WPM
 
 ## Features
 
-- 30-second typing challenges with real-time WPM tracking
-- Character-by-character validation with visual feedback
-- Global leaderboard with persistent scores
-- Dark/light theme support
-- Mobile-responsive design
-- Google SSO authentication
+-   30-second typing challenges with real-time WPM tracking
+-   Character-by-character validation with visual feedback
+-   Global leaderboard with persistent scores
+-   Dark/light theme support
+-   Mobile-responsive design
+-   Google SSO authentication
 
 ## Tech Stack
 
-| Category      | Technology                                    |
-| ------------- | --------------------------------------------- |
-| Framework     | [Next.js 14](https://nextjs.org/)             |
-| Language      | [TypeScript](https://www.typescriptlang.org/) |
-| Styling       | [Tailwind CSS](https://tailwindcss.com/)      |
-| Auth          | [Clerk](https://clerk.com/)                   |
-| Database      | [Convex](https://www.convex.dev/)             |
-| Charts        | [Nivo](https://nivo.rocks/)                   |
-| Deployment    | [Vercel](https://vercel.com/)                 |
+| Category   | Technology                                    |
+| ---------- | --------------------------------------------- |
+| Framework  | [Next.js 14](https://nextjs.org/)             |
+| Language   | [TypeScript](https://www.typescriptlang.org/) |
+| Styling    | [Tailwind CSS](https://tailwindcss.com/)      |
+| Auth       | [Clerk](https://clerk.com/)                   |
+| Database   | [Convex](https://www.convex.dev/)             |
+| Charts     | [Nivo](https://nivo.rocks/)                   |
+| Deployment | [Vercel](https://vercel.com/)                 |
 
 ## Getting Started
 
 ### Prerequisites
 
-- Node.js 18+
-- Yarn
-- Clerk account (for auth)
-- Convex account (for database)
+-   Node.js 18+
+-   Yarn
+-   Clerk account (for auth)
+-   Convex account (for database)
 
 ### Installation
 

--- a/convex.json
+++ b/convex.json
@@ -1,5 +1,5 @@
 {
-    "node": {
-        "version": "24"
-    }
+  "node": {
+    "version": "24"
+  }
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as corpus from "../corpus.js";
 import type * as leaderboard from "../leaderboard.js";
+import type * as races from "../races.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -27,6 +28,7 @@ import type * as leaderboard from "../leaderboard.js";
 declare const fullApi: ApiFromModules<{
   corpus: typeof corpus;
   leaderboard: typeof leaderboard;
+  races: typeof races;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/races.ts
+++ b/convex/races.ts
@@ -1,335 +1,316 @@
-import { mutation, query } from "./_generated/server";
-import { v } from "convex/values";
+import { mutation, query } from './_generated/server';
+import { v } from 'convex/values';
 
-// Generate a 6-character alphanumeric room code
 function generateRoomCode(): string {
-  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // Removed confusing chars (0, O, 1, I)
-  let code = "";
-  for (let i = 0; i < 6; i++) {
-    code += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return code;
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let code = '';
+    for (let i = 0; i < 6; i++) {
+        code += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return code;
 }
 
-// Create a new race room
 export const createRace = mutation({
-  args: {
-    hostId: v.string(),
-    hostUsername: v.string(),
-  },
-  handler: async (ctx, args) => {
-    // Get corpus for this race
-    const corpusDoc = await ctx.db.query("corpus").first();
-    if (!corpusDoc) {
-      throw new Error("No corpus available");
-    }
-
-    // Generate unique room code
-    let code = generateRoomCode();
-    let existing = await ctx.db
-      .query("races")
-      .withIndex("by_code", (q) => q.eq("code", code))
-      .first();
-
-    // Retry if code already exists
-    while (existing) {
-      code = generateRoomCode();
-      existing = await ctx.db
-        .query("races")
-        .withIndex("by_code", (q) => q.eq("code", code))
-        .first();
-    }
-
-    const raceId = await ctx.db.insert("races", {
-      code,
-      hostId: args.hostId,
-      hostUsername: args.hostUsername,
-      status: "waiting",
-      corpus: corpusDoc.words,
-      createdAt: Date.now(),
-    });
-
-    // Create host's progress entry
-    await ctx.db.insert("raceProgress", {
-      raceId,
-      odId: args.hostId,
-      charsTyped: 0,
-      wpm: 0,
-      finished: false,
-      disconnected: false,
-      updatedAt: Date.now(),
-    });
-
-    return { raceId, code };
-  },
-});
-
-// Join an existing race room
-export const joinRace = mutation({
-  args: {
-    code: v.string(),
-    guestId: v.string(),
-    guestUsername: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const race = await ctx.db
-      .query("races")
-      .withIndex("by_code", (q) => q.eq("code", args.code.toUpperCase()))
-      .first();
-
-    if (!race) {
-      throw new Error("Room not found");
-    }
-
-    if (race.status !== "waiting") {
-      throw new Error("Race has already started");
-    }
-
-    if (race.guestId) {
-      throw new Error("Room is full");
-    }
-
-    if (race.hostId === args.guestId) {
-      throw new Error("Cannot join your own room");
-    }
-
-    // Update race with guest info
-    await ctx.db.patch(race._id, {
-      guestId: args.guestId,
-      guestUsername: args.guestUsername,
-    });
-
-    // Create guest's progress entry
-    await ctx.db.insert("raceProgress", {
-      raceId: race._id,
-      odId: args.guestId,
-      charsTyped: 0,
-      wpm: 0,
-      finished: false,
-      disconnected: false,
-      updatedAt: Date.now(),
-    });
-
-    return { raceId: race._id, corpus: race.corpus };
-  },
-});
-
-// Start countdown (host only)
-export const startCountdown = mutation({
-  args: {
-    raceId: v.id("races"),
-    userId: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const race = await ctx.db.get(args.raceId);
-
-    if (!race) {
-      throw new Error("Race not found");
-    }
-
-    if (race.hostId !== args.userId) {
-      throw new Error("Only host can start the race");
-    }
-
-    if (!race.guestId) {
-      throw new Error("Waiting for opponent to join");
-    }
-
-    if (race.status !== "waiting") {
-      throw new Error("Race has already started");
-    }
-
-    await ctx.db.patch(args.raceId, {
-      status: "countdown",
-    });
-
-    return { success: true };
-  },
-});
-
-// Start racing (after countdown completes)
-export const startRacing = mutation({
-  args: {
-    raceId: v.id("races"),
-  },
-  handler: async (ctx, args) => {
-    const race = await ctx.db.get(args.raceId);
-
-    if (!race) {
-      throw new Error("Race not found");
-    }
-
-    if (race.status !== "countdown") {
-      throw new Error("Race is not in countdown");
-    }
-
-    await ctx.db.patch(args.raceId, {
-      status: "racing",
-      startTime: Date.now(),
-    });
-
-    return { success: true, startTime: Date.now() };
-  },
-});
-
-// Update player progress during race
-export const updateProgress = mutation({
-  args: {
-    raceId: v.id("races"),
-    userId: v.string(),
-    charsTyped: v.number(),
-    wpm: v.number(),
-  },
-  handler: async (ctx, args) => {
-    const progress = await ctx.db
-      .query("raceProgress")
-      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
-      .filter((q) => q.eq(q.field("odId"), args.userId))
-      .first();
-
-    if (!progress) {
-      throw new Error("Progress entry not found");
-    }
-
-    if (progress.finished || progress.disconnected) {
-      return { success: false };
-    }
-
-    await ctx.db.patch(progress._id, {
-      charsTyped: args.charsTyped,
-      wpm: args.wpm,
-      updatedAt: Date.now(),
-    });
-
-    return { success: true };
-  },
-});
-
-// Player finished the race
-export const finishRace = mutation({
-  args: {
-    raceId: v.id("races"),
-    userId: v.string(),
-    finalWpm: v.number(),
-    charsTyped: v.number(),
-  },
-  handler: async (ctx, args) => {
-    const progress = await ctx.db
-      .query("raceProgress")
-      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
-      .filter((q) => q.eq(q.field("odId"), args.userId))
-      .first();
-
-    if (!progress) {
-      throw new Error("Progress entry not found");
-    }
-
-    await ctx.db.patch(progress._id, {
-      charsTyped: args.charsTyped,
-      wpm: args.finalWpm,
-      finished: true,
-      finishTime: Date.now(),
-      updatedAt: Date.now(),
-    });
-
-    // Check if both players finished
-    const allProgress = await ctx.db
-      .query("raceProgress")
-      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
-      .collect();
-
-    const allFinished = allProgress.every((p) => p.finished || p.disconnected);
-
-    if (allFinished) {
-      await ctx.db.patch(args.raceId, {
-        status: "finished",
-      });
-    }
-
-    return { success: true };
-  },
-});
-
-// Player leaves/disconnects from race
-export const leaveRace = mutation({
-  args: {
-    raceId: v.id("races"),
-    userId: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const race = await ctx.db.get(args.raceId);
-
-    if (!race) {
-      return { success: false };
-    }
-
-    const progress = await ctx.db
-      .query("raceProgress")
-      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
-      .filter((q) => q.eq(q.field("odId"), args.userId))
-      .first();
-
-    if (progress) {
-      await ctx.db.patch(progress._id, {
-        disconnected: true,
-        updatedAt: Date.now(),
-      });
-    }
-
-    // If race hasn't started yet, clean up
-    if (race.status === "waiting") {
-      if (race.hostId === args.userId) {
-        // Host left, delete the race
-        const allProgress = await ctx.db
-          .query("raceProgress")
-          .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
-          .collect();
-
-        for (const p of allProgress) {
-          await ctx.db.delete(p._id);
+    args: {
+        hostId: v.string(),
+        hostUsername: v.string(),
+    },
+    handler: async (ctx, args) => {
+        // Get corpus for this race
+        const corpusDoc = await ctx.db.query('corpus').first();
+        if (!corpusDoc) {
+            throw new Error('No corpus available');
         }
-        await ctx.db.delete(args.raceId);
-      } else if (race.guestId === args.userId) {
-        // Guest left, remove them from race
-        await ctx.db.patch(args.raceId, {
-          guestId: undefined,
-          guestUsername: undefined,
+
+        let code = generateRoomCode();
+        let existing = await ctx.db
+            .query('races')
+            .withIndex('by_code', (q) => q.eq('code', code))
+            .first();
+
+        while (existing) {
+            code = generateRoomCode();
+            existing = await ctx.db
+                .query('races')
+                .withIndex('by_code', (q) => q.eq('code', code))
+                .first();
+        }
+
+        const raceId = await ctx.db.insert('races', {
+            code,
+            hostId: args.hostId,
+            hostUsername: args.hostUsername,
+            status: 'waiting',
+            corpus: corpusDoc.words,
+            createdAt: Date.now(),
         });
-      }
-    }
 
-    return { success: true };
-  },
+        await ctx.db.insert('raceProgress', {
+            raceId,
+            odId: args.hostId,
+            charsTyped: 0,
+            wpm: 0,
+            finished: false,
+            disconnected: false,
+            updatedAt: Date.now(),
+        });
+
+        return { raceId, code };
+    },
 });
 
-// Get race by code
+export const joinRace = mutation({
+    args: {
+        code: v.string(),
+        guestId: v.string(),
+        guestUsername: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const race = await ctx.db
+            .query('races')
+            .withIndex('by_code', (q) => q.eq('code', args.code.toUpperCase()))
+            .first();
+
+        if (!race) {
+            throw new Error('Room not found');
+        }
+
+        if (race.status !== 'waiting') {
+            throw new Error('Race has already started');
+        }
+
+        if (race.guestId) {
+            throw new Error('Room is full');
+        }
+
+        if (race.hostId === args.guestId) {
+            throw new Error('Cannot join your own room');
+        }
+
+        await ctx.db.patch(race._id, {
+            guestId: args.guestId,
+            guestUsername: args.guestUsername,
+        });
+
+        await ctx.db.insert('raceProgress', {
+            raceId: race._id,
+            odId: args.guestId,
+            charsTyped: 0,
+            wpm: 0,
+            finished: false,
+            disconnected: false,
+            updatedAt: Date.now(),
+        });
+
+        return { raceId: race._id, corpus: race.corpus };
+    },
+});
+
+export const startCountdown = mutation({
+    args: {
+        raceId: v.id('races'),
+        userId: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const race = await ctx.db.get(args.raceId);
+
+        if (!race) {
+            throw new Error('Race not found');
+        }
+
+        if (race.hostId !== args.userId) {
+            throw new Error('Only host can start the race');
+        }
+
+        if (!race.guestId) {
+            throw new Error('Waiting for opponent to join');
+        }
+
+        if (race.status !== 'waiting') {
+            throw new Error('Race has already started');
+        }
+
+        await ctx.db.patch(args.raceId, {
+            status: 'countdown',
+        });
+
+        return { success: true };
+    },
+});
+
+export const startRacing = mutation({
+    args: {
+        raceId: v.id('races'),
+    },
+    handler: async (ctx, args) => {
+        const race = await ctx.db.get(args.raceId);
+
+        if (!race) {
+            throw new Error('Race not found');
+        }
+
+        if (race.status !== 'countdown') {
+            throw new Error('Race is not in countdown');
+        }
+
+        await ctx.db.patch(args.raceId, {
+            status: 'racing',
+            startTime: Date.now(),
+        });
+
+        return { success: true, startTime: Date.now() };
+    },
+});
+
+export const updateProgress = mutation({
+    args: {
+        raceId: v.id('races'),
+        userId: v.string(),
+        charsTyped: v.number(),
+        wpm: v.number(),
+    },
+    handler: async (ctx, args) => {
+        const progress = await ctx.db
+            .query('raceProgress')
+            .withIndex('by_race', (q) => q.eq('raceId', args.raceId))
+            .filter((q) => q.eq(q.field('odId'), args.userId))
+            .first();
+
+        if (!progress) {
+            throw new Error('Progress entry not found');
+        }
+
+        if (progress.finished || progress.disconnected) {
+            return { success: false };
+        }
+
+        await ctx.db.patch(progress._id, {
+            charsTyped: args.charsTyped,
+            wpm: args.wpm,
+            updatedAt: Date.now(),
+        });
+
+        return { success: true };
+    },
+});
+
+export const finishRace = mutation({
+    args: {
+        raceId: v.id('races'),
+        userId: v.string(),
+        finalWpm: v.number(),
+        charsTyped: v.number(),
+    },
+    handler: async (ctx, args) => {
+        const progress = await ctx.db
+            .query('raceProgress')
+            .withIndex('by_race', (q) => q.eq('raceId', args.raceId))
+            .filter((q) => q.eq(q.field('odId'), args.userId))
+            .first();
+
+        if (!progress) {
+            throw new Error('Progress entry not found');
+        }
+
+        await ctx.db.patch(progress._id, {
+            charsTyped: args.charsTyped,
+            wpm: args.finalWpm,
+            finished: true,
+            finishTime: Date.now(),
+            updatedAt: Date.now(),
+        });
+
+        const allProgress = await ctx.db
+            .query('raceProgress')
+            .withIndex('by_race', (q) => q.eq('raceId', args.raceId))
+            .collect();
+
+        const allFinished = allProgress.every((p) => p.finished || p.disconnected);
+
+        if (allFinished) {
+            await ctx.db.patch(args.raceId, {
+                status: 'finished',
+            });
+        }
+
+        return { success: true };
+    },
+});
+
+export const leaveRace = mutation({
+    args: {
+        raceId: v.id('races'),
+        userId: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const race = await ctx.db.get(args.raceId);
+
+        if (!race) {
+            return { success: false };
+        }
+
+        const progress = await ctx.db
+            .query('raceProgress')
+            .withIndex('by_race', (q) => q.eq('raceId', args.raceId))
+            .filter((q) => q.eq(q.field('odId'), args.userId))
+            .first();
+
+        if (progress) {
+            await ctx.db.patch(progress._id, {
+                disconnected: true,
+                updatedAt: Date.now(),
+            });
+        }
+
+        if (race.status === 'waiting') {
+            if (race.hostId === args.userId) {
+                // Host left, delete the race
+                const allProgress = await ctx.db
+                    .query('raceProgress')
+                    .withIndex('by_race', (q) => q.eq('raceId', args.raceId))
+                    .collect();
+
+                for (const p of allProgress) {
+                    await ctx.db.delete(p._id);
+                }
+                await ctx.db.delete(args.raceId);
+            } else if (race.guestId === args.userId) {
+                await ctx.db.patch(args.raceId, {
+                    guestId: undefined,
+                    guestUsername: undefined,
+                });
+            }
+        }
+
+        return { success: true };
+    },
+});
+
 export const getRaceByCode = query({
-  args: { code: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("races")
-      .withIndex("by_code", (q) => q.eq("code", args.code.toUpperCase()))
-      .first();
-  },
+    args: { code: v.string() },
+    handler: async (ctx, args) => {
+        return await ctx.db
+            .query('races')
+            .withIndex('by_code', (q) => q.eq('code', args.code.toUpperCase()))
+            .first();
+    },
 });
 
-// Get race by ID
 export const getRace = query({
-  args: { raceId: v.id("races") },
-  handler: async (ctx, args) => {
-    return await ctx.db.get(args.raceId);
-  },
+    args: { raceId: v.id('races') },
+    handler: async (ctx, args) => {
+        return await ctx.db.get(args.raceId);
+    },
 });
 
-// Get race progress for both players (real-time subscription)
 export const getRaceProgress = query({
-  args: { raceId: v.id("races") },
-  handler: async (ctx, args) => {
-    const progress = await ctx.db
-      .query("raceProgress")
-      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
-      .collect();
+    args: { raceId: v.id('races') },
+    handler: async (ctx, args) => {
+        const progress = await ctx.db
+            .query('raceProgress')
+            .withIndex('by_race', (q) => q.eq('raceId', args.raceId))
+            .collect();
 
-    return progress;
-  },
+        return progress;
+    },
 });

--- a/convex/races.ts
+++ b/convex/races.ts
@@ -1,0 +1,335 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Generate a 6-character alphanumeric room code
+function generateRoomCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // Removed confusing chars (0, O, 1, I)
+  let code = "";
+  for (let i = 0; i < 6; i++) {
+    code += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return code;
+}
+
+// Create a new race room
+export const createRace = mutation({
+  args: {
+    hostId: v.string(),
+    hostUsername: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Get corpus for this race
+    const corpusDoc = await ctx.db.query("corpus").first();
+    if (!corpusDoc) {
+      throw new Error("No corpus available");
+    }
+
+    // Generate unique room code
+    let code = generateRoomCode();
+    let existing = await ctx.db
+      .query("races")
+      .withIndex("by_code", (q) => q.eq("code", code))
+      .first();
+
+    // Retry if code already exists
+    while (existing) {
+      code = generateRoomCode();
+      existing = await ctx.db
+        .query("races")
+        .withIndex("by_code", (q) => q.eq("code", code))
+        .first();
+    }
+
+    const raceId = await ctx.db.insert("races", {
+      code,
+      hostId: args.hostId,
+      hostUsername: args.hostUsername,
+      status: "waiting",
+      corpus: corpusDoc.words,
+      createdAt: Date.now(),
+    });
+
+    // Create host's progress entry
+    await ctx.db.insert("raceProgress", {
+      raceId,
+      odId: args.hostId,
+      charsTyped: 0,
+      wpm: 0,
+      finished: false,
+      disconnected: false,
+      updatedAt: Date.now(),
+    });
+
+    return { raceId, code };
+  },
+});
+
+// Join an existing race room
+export const joinRace = mutation({
+  args: {
+    code: v.string(),
+    guestId: v.string(),
+    guestUsername: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const race = await ctx.db
+      .query("races")
+      .withIndex("by_code", (q) => q.eq("code", args.code.toUpperCase()))
+      .first();
+
+    if (!race) {
+      throw new Error("Room not found");
+    }
+
+    if (race.status !== "waiting") {
+      throw new Error("Race has already started");
+    }
+
+    if (race.guestId) {
+      throw new Error("Room is full");
+    }
+
+    if (race.hostId === args.guestId) {
+      throw new Error("Cannot join your own room");
+    }
+
+    // Update race with guest info
+    await ctx.db.patch(race._id, {
+      guestId: args.guestId,
+      guestUsername: args.guestUsername,
+    });
+
+    // Create guest's progress entry
+    await ctx.db.insert("raceProgress", {
+      raceId: race._id,
+      odId: args.guestId,
+      charsTyped: 0,
+      wpm: 0,
+      finished: false,
+      disconnected: false,
+      updatedAt: Date.now(),
+    });
+
+    return { raceId: race._id, corpus: race.corpus };
+  },
+});
+
+// Start countdown (host only)
+export const startCountdown = mutation({
+  args: {
+    raceId: v.id("races"),
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const race = await ctx.db.get(args.raceId);
+
+    if (!race) {
+      throw new Error("Race not found");
+    }
+
+    if (race.hostId !== args.userId) {
+      throw new Error("Only host can start the race");
+    }
+
+    if (!race.guestId) {
+      throw new Error("Waiting for opponent to join");
+    }
+
+    if (race.status !== "waiting") {
+      throw new Error("Race has already started");
+    }
+
+    await ctx.db.patch(args.raceId, {
+      status: "countdown",
+    });
+
+    return { success: true };
+  },
+});
+
+// Start racing (after countdown completes)
+export const startRacing = mutation({
+  args: {
+    raceId: v.id("races"),
+  },
+  handler: async (ctx, args) => {
+    const race = await ctx.db.get(args.raceId);
+
+    if (!race) {
+      throw new Error("Race not found");
+    }
+
+    if (race.status !== "countdown") {
+      throw new Error("Race is not in countdown");
+    }
+
+    await ctx.db.patch(args.raceId, {
+      status: "racing",
+      startTime: Date.now(),
+    });
+
+    return { success: true, startTime: Date.now() };
+  },
+});
+
+// Update player progress during race
+export const updateProgress = mutation({
+  args: {
+    raceId: v.id("races"),
+    userId: v.string(),
+    charsTyped: v.number(),
+    wpm: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const progress = await ctx.db
+      .query("raceProgress")
+      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
+      .filter((q) => q.eq(q.field("odId"), args.userId))
+      .first();
+
+    if (!progress) {
+      throw new Error("Progress entry not found");
+    }
+
+    if (progress.finished || progress.disconnected) {
+      return { success: false };
+    }
+
+    await ctx.db.patch(progress._id, {
+      charsTyped: args.charsTyped,
+      wpm: args.wpm,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
+  },
+});
+
+// Player finished the race
+export const finishRace = mutation({
+  args: {
+    raceId: v.id("races"),
+    userId: v.string(),
+    finalWpm: v.number(),
+    charsTyped: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const progress = await ctx.db
+      .query("raceProgress")
+      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
+      .filter((q) => q.eq(q.field("odId"), args.userId))
+      .first();
+
+    if (!progress) {
+      throw new Error("Progress entry not found");
+    }
+
+    await ctx.db.patch(progress._id, {
+      charsTyped: args.charsTyped,
+      wpm: args.finalWpm,
+      finished: true,
+      finishTime: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    // Check if both players finished
+    const allProgress = await ctx.db
+      .query("raceProgress")
+      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
+      .collect();
+
+    const allFinished = allProgress.every((p) => p.finished || p.disconnected);
+
+    if (allFinished) {
+      await ctx.db.patch(args.raceId, {
+        status: "finished",
+      });
+    }
+
+    return { success: true };
+  },
+});
+
+// Player leaves/disconnects from race
+export const leaveRace = mutation({
+  args: {
+    raceId: v.id("races"),
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const race = await ctx.db.get(args.raceId);
+
+    if (!race) {
+      return { success: false };
+    }
+
+    const progress = await ctx.db
+      .query("raceProgress")
+      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
+      .filter((q) => q.eq(q.field("odId"), args.userId))
+      .first();
+
+    if (progress) {
+      await ctx.db.patch(progress._id, {
+        disconnected: true,
+        updatedAt: Date.now(),
+      });
+    }
+
+    // If race hasn't started yet, clean up
+    if (race.status === "waiting") {
+      if (race.hostId === args.userId) {
+        // Host left, delete the race
+        const allProgress = await ctx.db
+          .query("raceProgress")
+          .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
+          .collect();
+
+        for (const p of allProgress) {
+          await ctx.db.delete(p._id);
+        }
+        await ctx.db.delete(args.raceId);
+      } else if (race.guestId === args.userId) {
+        // Guest left, remove them from race
+        await ctx.db.patch(args.raceId, {
+          guestId: undefined,
+          guestUsername: undefined,
+        });
+      }
+    }
+
+    return { success: true };
+  },
+});
+
+// Get race by code
+export const getRaceByCode = query({
+  args: { code: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("races")
+      .withIndex("by_code", (q) => q.eq("code", args.code.toUpperCase()))
+      .first();
+  },
+});
+
+// Get race by ID
+export const getRace = query({
+  args: { raceId: v.id("races") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.raceId);
+  },
+});
+
+// Get race progress for both players (real-time subscription)
+export const getRaceProgress = query({
+  args: { raceId: v.id("races") },
+  handler: async (ctx, args) => {
+    const progress = await ctx.db
+      .query("raceProgress")
+      .withIndex("by_race", (q) => q.eq("raceId", args.raceId))
+      .collect();
+
+    return progress;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -18,4 +18,31 @@ export default defineSchema({
     })
         .index('by_userId', ['userId'])
         .index('by_username', ['username']),
+
+    // Multiplayer race rooms
+    races: defineTable({
+        code: v.string(), // 6-char room code
+        hostId: v.string(), // Clerk user ID
+        guestId: v.optional(v.string()),
+        hostUsername: v.string(),
+        guestUsername: v.optional(v.string()),
+        status: v.string(), // "waiting" | "countdown" | "racing" | "finished"
+        corpus: v.string(), // Typing text for this race
+        startTime: v.optional(v.number()), // When race actually starts (after countdown)
+        createdAt: v.number(),
+    })
+        .index('by_code', ['code'])
+        .index('by_status', ['status']),
+
+    // Player progress during race
+    raceProgress: defineTable({
+        raceId: v.id('races'),
+        odId: v.string(), // Clerk user ID
+        charsTyped: v.number(),
+        wpm: v.number(),
+        finished: v.boolean(),
+        finishTime: v.optional(v.number()),
+        disconnected: v.boolean(),
+        updatedAt: v.number(),
+    }).index('by_race', ['raceId']),
 });

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -51,7 +51,12 @@ export function initTelemetry() {
     registerInstrumentations({
         instrumentations: [
             new FetchInstrumentation({
-                propagateTraceHeaderCorsUrls: [/.*/],
+                // Only propagate trace headers to our own backend, not third-party services like Clerk
+                propagateTraceHeaderCorsUrls: [
+                    /localhost/,
+                    /vercel\.app\/api/,
+                    /convex\.cloud/,
+                ],
                 clearTimingResources: true,
             }),
             new DocumentLoadInstrumentation(),

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,4 +1,10 @@
-import { WebTracerProvider, BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-web';
+import {
+    WebTracerProvider,
+    BatchSpanProcessor,
+    SimpleSpanProcessor,
+    ConsoleSpanExporter,
+    SpanProcessor,
+} from '@opentelemetry/sdk-trace-web';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { resourceFromAttributes } from '@opentelemetry/resources';

--- a/src/pages/components/MultiplayerLobby.tsx
+++ b/src/pages/components/MultiplayerLobby.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+
+type Props = {
+    onCreateRoom: () => void;
+    onJoinRoom: (code: string) => void;
+    onBack: () => void;
+};
+
+export default function MultiplayerLobby({ onCreateRoom, onJoinRoom, onBack }: Props) {
+    const [showJoinInput, setShowJoinInput] = useState(false);
+    const [joinCode, setJoinCode] = useState('');
+
+    const handleJoinSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (joinCode.trim().length === 6) {
+            onJoinRoom(joinCode.trim());
+        }
+    };
+
+    return (
+        <div className="space-y-8">
+            <h1 className="text-4xl font-bold mb-8">Multiplayer Race</h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-8">
+                Race against a friend in real-time!
+            </p>
+
+            {!showJoinInput ? (
+                <div className="space-y-4">
+                    <button
+                        onClick={onCreateRoom}
+                        className="w-full max-w-xs mx-auto block bg-black dark:bg-white text-white dark:text-black font-bold py-4 px-8 rounded-full hover:opacity-80 transition-opacity"
+                    >
+                        Create Room
+                    </button>
+                    <button
+                        onClick={() => setShowJoinInput(true)}
+                        className="w-full max-w-xs mx-auto block border-2 border-black dark:border-white text-black dark:text-white font-bold py-4 px-8 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                    >
+                        Join Room
+                    </button>
+                    <button
+                        onClick={onBack}
+                        className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 mt-4"
+                    >
+                        Back to Solo Race
+                    </button>
+                </div>
+            ) : (
+                <form onSubmit={handleJoinSubmit} className="space-y-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Enter Room Code
+                        </label>
+                        <input
+                            type="text"
+                            value={joinCode}
+                            onChange={(e) => setJoinCode(e.target.value.toUpperCase().slice(0, 6))}
+                            placeholder="ABC123"
+                            className="w-full max-w-xs mx-auto block text-center text-2xl tracking-widest py-3 px-4 border-2 border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 focus:outline-none focus:border-black dark:focus:border-white"
+                            autoFocus
+                        />
+                    </div>
+                    <div className="flex gap-4 justify-center">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setShowJoinInput(false);
+                                setJoinCode('');
+                            }}
+                            className="border-2 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 font-bold py-2 px-6 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={joinCode.length !== 6}
+                            className="bg-black dark:bg-white text-white dark:text-black font-bold py-2 px-6 rounded-full hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            Join
+                        </button>
+                    </div>
+                </form>
+            )}
+        </div>
+    );
+}

--- a/src/pages/components/MultiplayerLobby.tsx
+++ b/src/pages/components/MultiplayerLobby.tsx
@@ -48,9 +48,7 @@ export default function MultiplayerLobby({ onCreateRoom, onJoinRoom, onBack }: P
             ) : (
                 <form onSubmit={handleJoinSubmit} className="space-y-4">
                     <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Enter Room Code
-                        </label>
+                        <label className="block text-sm font-medium mb-2">Enter Room Code</label>
                         <input
                             type="text"
                             value={joinCode}

--- a/src/pages/components/MultiplayerResults.tsx
+++ b/src/pages/components/MultiplayerResults.tsx
@@ -23,20 +23,24 @@ export default function MultiplayerResults({
     return (
         <div className="space-y-8">
             {/* Winner Banner */}
-            <div className={`p-6 rounded-lg ${
-                isTie
-                    ? 'bg-gray-100 dark:bg-gray-800'
-                    : didWin
+            <div
+                className={`p-6 rounded-lg ${
+                    isTie
+                        ? 'bg-gray-100 dark:bg-gray-800'
+                        : didWin
                         ? 'bg-green-100 dark:bg-green-900'
                         : 'bg-red-100 dark:bg-red-900'
-            }`}>
-                <h2 className={`text-3xl font-bold ${
-                    isTie
-                        ? 'text-gray-700 dark:text-gray-300'
-                        : didWin
+                }`}
+            >
+                <h2
+                    className={`text-3xl font-bold ${
+                        isTie
+                            ? 'text-gray-700 dark:text-gray-300'
+                            : didWin
                             ? 'text-green-700 dark:text-green-300'
                             : 'text-red-700 dark:text-red-300'
-                }`}>
+                    }`}
+                >
                     {isTie ? "It's a Tie!" : didWin ? 'You Win!' : 'You Lose!'}
                 </h2>
                 {opponentDisconnected && (
@@ -71,11 +75,19 @@ export default function MultiplayerResults({
                             </td>
                         </tr>
                         <tr>
-                            <td className={`py-3 font-medium ${opponentDisconnected ? 'text-gray-400' : ''}`}>
+                            <td
+                                className={`py-3 font-medium ${
+                                    opponentDisconnected ? 'text-gray-400' : ''
+                                }`}
+                            >
                                 {opponentUsername}
                                 {opponentDisconnected && ' (DNF)'}
                             </td>
-                            <td className={`text-right py-3 ${opponentDisconnected ? 'text-gray-400' : ''}`}>
+                            <td
+                                className={`text-right py-3 ${
+                                    opponentDisconnected ? 'text-gray-400' : ''
+                                }`}
+                            >
                                 {opponentDisconnected ? '-' : opponentWpm}
                             </td>
                             <td className="text-right py-3">

--- a/src/pages/components/MultiplayerResults.tsx
+++ b/src/pages/components/MultiplayerResults.tsx
@@ -1,0 +1,114 @@
+type Props = {
+    myWpm: number;
+    opponentWpm: number;
+    myUsername: string;
+    opponentUsername: string;
+    opponentDisconnected: boolean;
+    onRaceAgain: () => void;
+    onLeave: () => void;
+};
+
+export default function MultiplayerResults({
+    myWpm,
+    opponentWpm,
+    myUsername,
+    opponentUsername,
+    opponentDisconnected,
+    onRaceAgain,
+    onLeave,
+}: Props) {
+    const didWin = opponentDisconnected || myWpm > opponentWpm;
+    const isTie = !opponentDisconnected && myWpm === opponentWpm;
+
+    return (
+        <div className="space-y-8">
+            {/* Winner Banner */}
+            <div className={`p-6 rounded-lg ${
+                isTie
+                    ? 'bg-gray-100 dark:bg-gray-800'
+                    : didWin
+                        ? 'bg-green-100 dark:bg-green-900'
+                        : 'bg-red-100 dark:bg-red-900'
+            }`}>
+                <h2 className={`text-3xl font-bold ${
+                    isTie
+                        ? 'text-gray-700 dark:text-gray-300'
+                        : didWin
+                            ? 'text-green-700 dark:text-green-300'
+                            : 'text-red-700 dark:text-red-300'
+                }`}>
+                    {isTie ? "It's a Tie!" : didWin ? 'You Win!' : 'You Lose!'}
+                </h2>
+                {opponentDisconnected && (
+                    <p className="text-sm text-gray-500 mt-2">
+                        Opponent disconnected from the race
+                    </p>
+                )}
+            </div>
+
+            {/* Results Table */}
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
+                <table className="w-full">
+                    <thead>
+                        <tr className="border-b border-gray-200 dark:border-gray-700">
+                            <th className="text-left py-2">Player</th>
+                            <th className="text-right py-2">WPM</th>
+                            <th className="text-right py-2">Result</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr className="border-b border-gray-100 dark:border-gray-700">
+                            <td className="py-3 font-medium">{myUsername} (You)</td>
+                            <td className="text-right py-3">{myWpm}</td>
+                            <td className="text-right py-3">
+                                {isTie ? (
+                                    <span className="text-gray-500">Tie</span>
+                                ) : didWin ? (
+                                    <span className="text-green-500">Winner</span>
+                                ) : (
+                                    <span className="text-red-500">-</span>
+                                )}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className={`py-3 font-medium ${opponentDisconnected ? 'text-gray-400' : ''}`}>
+                                {opponentUsername}
+                                {opponentDisconnected && ' (DNF)'}
+                            </td>
+                            <td className={`text-right py-3 ${opponentDisconnected ? 'text-gray-400' : ''}`}>
+                                {opponentDisconnected ? '-' : opponentWpm}
+                            </td>
+                            <td className="text-right py-3">
+                                {opponentDisconnected ? (
+                                    <span className="text-gray-400">DNF</span>
+                                ) : isTie ? (
+                                    <span className="text-gray-500">Tie</span>
+                                ) : !didWin ? (
+                                    <span className="text-green-500">Winner</span>
+                                ) : (
+                                    <span className="text-red-500">-</span>
+                                )}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-col gap-4">
+                <button
+                    onClick={onRaceAgain}
+                    className="bg-black dark:bg-white text-white dark:text-black font-bold py-3 px-8 rounded-full hover:opacity-80 transition-opacity"
+                >
+                    Race Again
+                </button>
+                <button
+                    onClick={onLeave}
+                    className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                >
+                    Back to Solo Race
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/components/RaceProgress.tsx
+++ b/src/pages/components/RaceProgress.tsx
@@ -13,13 +13,11 @@ type Props = {
 
 export default function RaceProgress({ myProgress, opponentProgress, totalChars }: Props) {
     const myPercentage = totalChars > 0 ? (myProgress.charsTyped / totalChars) * 100 : 0;
-    const opponentPercentage = opponentProgress && totalChars > 0
-        ? (opponentProgress.charsTyped / totalChars) * 100
-        : 0;
+    const opponentPercentage =
+        opponentProgress && totalChars > 0 ? (opponentProgress.charsTyped / totalChars) * 100 : 0;
 
     return (
         <div className="mb-6 space-y-3">
-            {/* My Progress */}
             <div className="space-y-1">
                 <div className="flex justify-between text-sm">
                     <span className="font-medium">{myProgress.username} (You)</span>
@@ -37,7 +35,11 @@ export default function RaceProgress({ myProgress, opponentProgress, totalChars 
             {opponentProgress && (
                 <div className="space-y-1">
                     <div className="flex justify-between text-sm">
-                        <span className={`font-medium ${opponentProgress.disconnected ? 'text-gray-400' : ''}`}>
+                        <span
+                            className={`font-medium ${
+                                opponentProgress.disconnected ? 'text-gray-400' : ''
+                            }`}
+                        >
                             {opponentProgress.username}
                             {opponentProgress.disconnected && ' (Disconnected)'}
                         </span>

--- a/src/pages/components/RaceProgress.tsx
+++ b/src/pages/components/RaceProgress.tsx
@@ -1,0 +1,60 @@
+type PlayerProgress = {
+    charsTyped: number;
+    wpm: number;
+    username: string;
+    disconnected?: boolean;
+};
+
+type Props = {
+    myProgress: PlayerProgress;
+    opponentProgress?: PlayerProgress;
+    totalChars: number;
+};
+
+export default function RaceProgress({ myProgress, opponentProgress, totalChars }: Props) {
+    const myPercentage = totalChars > 0 ? (myProgress.charsTyped / totalChars) * 100 : 0;
+    const opponentPercentage = opponentProgress && totalChars > 0
+        ? (opponentProgress.charsTyped / totalChars) * 100
+        : 0;
+
+    return (
+        <div className="mb-6 space-y-3">
+            {/* My Progress */}
+            <div className="space-y-1">
+                <div className="flex justify-between text-sm">
+                    <span className="font-medium">{myProgress.username} (You)</span>
+                    <span>{myProgress.wpm} WPM</span>
+                </div>
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                    <div
+                        className="h-full bg-blue-500 transition-all duration-300 ease-out"
+                        style={{ width: `${Math.min(myPercentage, 100)}%` }}
+                    />
+                </div>
+            </div>
+
+            {/* Opponent Progress */}
+            {opponentProgress && (
+                <div className="space-y-1">
+                    <div className="flex justify-between text-sm">
+                        <span className={`font-medium ${opponentProgress.disconnected ? 'text-gray-400' : ''}`}>
+                            {opponentProgress.username}
+                            {opponentProgress.disconnected && ' (Disconnected)'}
+                        </span>
+                        <span className={opponentProgress.disconnected ? 'text-gray-400' : ''}>
+                            {opponentProgress.wpm} WPM
+                        </span>
+                    </div>
+                    <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                        <div
+                            className={`h-full transition-all duration-300 ease-out ${
+                                opponentProgress.disconnected ? 'bg-gray-400' : 'bg-red-500'
+                            }`}
+                            style={{ width: `${Math.min(opponentPercentage, 100)}%` }}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/pages/components/WaitingRoom.tsx
+++ b/src/pages/components/WaitingRoom.tsx
@@ -3,7 +3,9 @@ import { useState } from 'react';
 type Props = {
     roomCode: string;
     isHost: boolean;
-    opponentUsername?: string;
+    myUsername: string;
+    hostUsername: string;
+    guestUsername?: string;
     onStartRace: () => void;
     onLeave: () => void;
 };
@@ -11,7 +13,9 @@ type Props = {
 export default function WaitingRoom({
     roomCode,
     isHost,
-    opponentUsername,
+    myUsername,
+    hostUsername,
+    guestUsername,
     onStartRace,
     onLeave,
 }: Props) {
@@ -62,18 +66,19 @@ export default function WaitingRoom({
                     <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded">
                         <span className="flex items-center gap-2">
                             <span className="w-2 h-2 bg-green-500 rounded-full"></span>
-                            {isHost ? 'You (Host)' : 'Host'}
+                            {hostUsername} {isHost && '(You)'}
+                            <span className="text-xs text-gray-500 ml-1">Host</span>
                         </span>
-                        {isHost && <span className="text-xs text-gray-500">Ready</span>}
+                        <span className="text-xs text-gray-500">Ready</span>
                     </div>
 
                     {/* Guest */}
                     <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded">
                         <span className="flex items-center gap-2">
-                            {opponentUsername ? (
+                            {guestUsername ? (
                                 <>
                                     <span className="w-2 h-2 bg-green-500 rounded-full"></span>
-                                    {opponentUsername}
+                                    {guestUsername} {!isHost && '(You)'}
                                 </>
                             ) : (
                                 <>
@@ -82,7 +87,7 @@ export default function WaitingRoom({
                                 </>
                             )}
                         </span>
-                        {opponentUsername && <span className="text-xs text-gray-500">Ready</span>}
+                        {guestUsername && <span className="text-xs text-gray-500">Ready</span>}
                     </div>
                 </div>
             </div>
@@ -92,10 +97,10 @@ export default function WaitingRoom({
                 {isHost && (
                     <button
                         onClick={onStartRace}
-                        disabled={!opponentUsername}
+                        disabled={!guestUsername}
                         className="bg-black dark:bg-white text-white dark:text-black font-bold py-3 px-8 rounded-full hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                        {opponentUsername ? 'Start Race' : 'Waiting for opponent...'}
+                        {guestUsername ? 'Start Race' : 'Waiting for opponent...'}
                     </button>
                 )}
                 {!isHost && (

--- a/src/pages/components/WaitingRoom.tsx
+++ b/src/pages/components/WaitingRoom.tsx
@@ -31,27 +31,44 @@ export default function WaitingRoom({
         <div className="space-y-8">
             <h2 className="text-2xl font-bold">Waiting Room</h2>
 
-            {/* Room Code Display */}
             <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
                 <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
                     Share this code with your friend:
                 </p>
                 <div className="flex items-center justify-center gap-4">
-                    <span className="text-4xl font-mono font-bold tracking-widest">
-                        {roomCode}
-                    </span>
+                    <span className="text-4xl font-mono font-bold tracking-widest">{roomCode}</span>
                     <button
                         onClick={copyCode}
                         className="p-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
                         title="Copy code"
                     >
                         {copied ? (
-                            <svg className="w-6 h-6 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            <svg
+                                className="w-6 h-6 text-green-500"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M5 13l4 4L19 7"
+                                />
                             </svg>
                         ) : (
-                            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            <svg
+                                className="w-6 h-6"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                                />
                             </svg>
                         )}
                     </button>

--- a/src/pages/components/WaitingRoom.tsx
+++ b/src/pages/components/WaitingRoom.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+
+type Props = {
+    roomCode: string;
+    isHost: boolean;
+    opponentUsername?: string;
+    onStartRace: () => void;
+    onLeave: () => void;
+};
+
+export default function WaitingRoom({
+    roomCode,
+    isHost,
+    opponentUsername,
+    onStartRace,
+    onLeave,
+}: Props) {
+    const [copied, setCopied] = useState(false);
+
+    const copyCode = async () => {
+        await navigator.clipboard.writeText(roomCode);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+        <div className="space-y-8">
+            <h2 className="text-2xl font-bold">Waiting Room</h2>
+
+            {/* Room Code Display */}
+            <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    Share this code with your friend:
+                </p>
+                <div className="flex items-center justify-center gap-4">
+                    <span className="text-4xl font-mono font-bold tracking-widest">
+                        {roomCode}
+                    </span>
+                    <button
+                        onClick={copyCode}
+                        className="p-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+                        title="Copy code"
+                    >
+                        {copied ? (
+                            <svg className="w-6 h-6 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                        ) : (
+                            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                        )}
+                    </button>
+                </div>
+            </div>
+
+            {/* Players */}
+            <div className="space-y-4">
+                <h3 className="text-lg font-medium">Players</h3>
+                <div className="flex flex-col gap-2">
+                    {/* Host */}
+                    <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded">
+                        <span className="flex items-center gap-2">
+                            <span className="w-2 h-2 bg-green-500 rounded-full"></span>
+                            {isHost ? 'You (Host)' : 'Host'}
+                        </span>
+                        {isHost && <span className="text-xs text-gray-500">Ready</span>}
+                    </div>
+
+                    {/* Guest */}
+                    <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded">
+                        <span className="flex items-center gap-2">
+                            {opponentUsername ? (
+                                <>
+                                    <span className="w-2 h-2 bg-green-500 rounded-full"></span>
+                                    {opponentUsername}
+                                </>
+                            ) : (
+                                <>
+                                    <span className="w-2 h-2 bg-gray-400 rounded-full animate-pulse"></span>
+                                    <span className="text-gray-400">Waiting for opponent...</span>
+                                </>
+                            )}
+                        </span>
+                        {opponentUsername && <span className="text-xs text-gray-500">Ready</span>}
+                    </div>
+                </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-col gap-4">
+                {isHost && (
+                    <button
+                        onClick={onStartRace}
+                        disabled={!opponentUsername}
+                        className="bg-black dark:bg-white text-white dark:text-black font-bold py-3 px-8 rounded-full hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        {opponentUsername ? 'Start Race' : 'Waiting for opponent...'}
+                    </button>
+                )}
+                {!isHost && (
+                    <p className="text-gray-500 dark:text-gray-400">
+                        Waiting for host to start the race...
+                    </p>
+                )}
+                <button
+                    onClick={onLeave}
+                    className="text-red-500 hover:text-red-700 dark:hover:text-red-400"
+                >
+                    Leave Room
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -120,6 +120,12 @@ export default function LandingPage() {
                             >
                                 Race Me
                             </button>
+                            <button
+                                onClick={() => router.push('/multiplayer')}
+                                className="border-2 border-black dark:border-white hover:bg-gray-100 dark:hover:bg-gray-800 text-black dark:text-white font-semibold py-4 px-8 rounded-full transition-colors text-lg"
+                            >
+                                Multiplayer
+                            </button>
                             <SignInButton mode="modal" redirectUrl="/typer-racer">
                                 <button className="border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-semibold py-4 px-8 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 text-lg">
                                     Sign In for Leaderboard

--- a/src/pages/multiplayer.tsx
+++ b/src/pages/multiplayer.tsx
@@ -1,0 +1,400 @@
+import { AngelIcon, DevilIcon } from '@/assets/images';
+import ToggleButton from '@/components/ToggleButton/ToggleButton';
+import TypingLoader from '@/components/TypingLoader';
+import { useTheme } from 'next-themes';
+import Head from 'next/head';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { GetServerSideProps } from 'next';
+import { buildClerkProps, clerkClient, getAuth } from '@clerk/nextjs/server';
+import { useUser } from '@clerk/nextjs';
+import { useRouter } from 'next/router';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '../../convex/_generated/api';
+import { Id } from '../../convex/_generated/dataModel';
+import MultiplayerLobby from './components/MultiplayerLobby';
+import WaitingRoom from './components/WaitingRoom';
+import RaceProgress from './components/RaceProgress';
+import MultiplayerResults from './components/MultiplayerResults';
+import TypingBoard from './components/TypingBoard';
+import useKeyPress from '@/hooks/useKeyPress';
+import { useIsSm } from '@/hooks/useMediaQuery';
+
+type Props = {
+    userInfo: {
+        id: string;
+        username: string;
+        emailAddresses?: Array<{ emailAddress: string }>;
+    };
+};
+
+type GameState = 'lobby' | 'waiting' | 'countdown' | 'racing' | 'finished';
+
+export default function Multiplayer({ userInfo }: Props) {
+    const { theme } = useTheme();
+    const { isSignedIn, isLoaded } = useUser();
+    const router = useRouter();
+    const isSm = useIsSm();
+    const [isLoading, setIsLoading] = useState(true);
+
+    // Game state
+    const [gameState, setGameState] = useState<GameState>('lobby');
+    const [raceId, setRaceId] = useState<Id<'races'> | null>(null);
+    const [roomCode, setRoomCode] = useState<string>('');
+    const [isHost, setIsHost] = useState(false);
+    const [countdown, setCountdown] = useState(3);
+    const [error, setError] = useState<string>('');
+
+    // Typing state
+    const [corpus, setCorpus] = useState<string>('');
+    const [leftPadding, setLeftPadding] = useState(new Array(isSm ? 25 : 30).fill(' ').join(''));
+    const [outgoingChars, setOutgoingChars] = useState<string>('');
+    const [incorrectChar, setIncorrectChar] = useState<boolean>(false);
+    const [currentChar, setCurrentChar] = useState<string>('');
+    const [incomingChars, setIncomingChars] = useState<string>('');
+    const [charCount, setCharCount] = useState<number>(0);
+    const [wpm, setWpm] = useState<number>(0);
+    const [seconds, setSeconds] = useState<number>(30);
+    const [startTime, setStartTime] = useState<number>(0);
+
+    // Convex mutations
+    const createRace = useMutation(api.races.createRace);
+    const joinRace = useMutation(api.races.joinRace);
+    const startCountdown = useMutation(api.races.startCountdown);
+    const startRacing = useMutation(api.races.startRacing);
+    const updateProgress = useMutation(api.races.updateProgress);
+    const finishRace = useMutation(api.races.finishRace);
+    const leaveRace = useMutation(api.races.leaveRace);
+
+    // Convex queries - subscribe to real-time updates
+    const race = useQuery(api.races.getRace, raceId ? { raceId } : 'skip');
+    const raceProgress = useQuery(api.races.getRaceProgress, raceId ? { raceId } : 'skip');
+
+    const tabIcon = useMemo(
+        () => (theme === 'light' ? AngelIcon.src : DevilIcon.src),
+        [theme]
+    );
+
+    // Auth check
+    useEffect(() => {
+        if (isLoaded) {
+            if (!isSignedIn) {
+                router.push('/');
+            } else {
+                setIsLoading(false);
+            }
+        }
+    }, [isSignedIn, isLoaded, router]);
+
+    // Watch for race status changes
+    useEffect(() => {
+        if (!race) return;
+
+        if (race.status === 'countdown' && gameState !== 'countdown') {
+            setGameState('countdown');
+            setCountdown(3);
+        } else if (race.status === 'racing' && gameState !== 'racing') {
+            setGameState('racing');
+            setStartTime(race.startTime || Date.now());
+        } else if (race.status === 'finished' && gameState !== 'finished') {
+            setGameState('finished');
+        }
+    }, [race?.status, gameState, race?.startTime, race]);
+
+    // Countdown timer
+    useEffect(() => {
+        if (gameState !== 'countdown') return;
+
+        if (countdown > 0) {
+            const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
+            return () => clearTimeout(timer);
+        } else {
+            // Countdown finished, start racing
+            if (isHost && raceId) {
+                startRacing({ raceId });
+            }
+        }
+    }, [countdown, gameState, isHost, raceId, startRacing]);
+
+    // Race timer
+    useEffect(() => {
+        if (gameState !== 'racing' || !startTime) return;
+
+        if (seconds > 0) {
+            const timer = setTimeout(() => {
+                setSeconds(seconds - 1);
+                const durationInMinutes = (Date.now() - startTime) / 60000.0;
+                const newWpm = Number((charCount / 5 / durationInMinutes).toFixed(2));
+                setWpm(newWpm);
+            }, 1000);
+            return () => clearTimeout(timer);
+        } else {
+            // Time's up
+            if (raceId) {
+                finishRace({ raceId, userId: userInfo.id, finalWpm: wpm, charsTyped: charCount });
+            }
+        }
+    }, [seconds, gameState, startTime, charCount, wpm, raceId, userInfo.id, finishRace]);
+
+    // Progress update throttle
+    const [lastProgressUpdate, setLastProgressUpdate] = useState(0);
+
+    // Key press handler
+    useKeyPress({
+        callback: (key) => {
+            if (gameState !== 'racing' || seconds === 0) return;
+
+            if (key === currentChar) {
+                setIncorrectChar(false);
+                if (leftPadding.length > 0) {
+                    setLeftPadding(leftPadding.substring(1));
+                }
+
+                const newOutgoing = outgoingChars + currentChar;
+                setOutgoingChars(newOutgoing);
+                setCurrentChar(incomingChars.charAt(0));
+                setIncomingChars(incomingChars.substring(1));
+
+                const newCharCount = charCount + 1;
+                setCharCount(newCharCount);
+
+                // Check if finished typing all chars
+                if (incomingChars.length === 0) {
+                    if (raceId) {
+                        const durationInMinutes = (Date.now() - startTime) / 60000.0;
+                        const finalWpm = Number((newCharCount / 5 / durationInMinutes).toFixed(2));
+                        finishRace({ raceId, userId: userInfo.id, finalWpm, charsTyped: newCharCount });
+                    }
+                    return;
+                }
+
+                // Throttle progress updates to every 500ms
+                const now = Date.now();
+                if (raceId && now - lastProgressUpdate > 500) {
+                    const durationInMinutes = (now - startTime) / 60000.0;
+                    const currentWpm = Number((newCharCount / 5 / durationInMinutes).toFixed(2));
+                    updateProgress({ raceId, userId: userInfo.id, charsTyped: newCharCount, wpm: currentWpm });
+                    setLastProgressUpdate(now);
+                }
+            } else {
+                setIncorrectChar(true);
+            }
+        },
+    });
+
+    // Create room handler
+    const handleCreateRoom = useCallback(async () => {
+        try {
+            setError('');
+            const result = await createRace({
+                hostId: userInfo.id,
+                hostUsername: userInfo.username,
+            });
+            setRaceId(result.raceId);
+            setRoomCode(result.code);
+            setIsHost(true);
+            setGameState('waiting');
+        } catch (e) {
+            setError(e instanceof Error ? e.message : 'Failed to create room');
+        }
+    }, [createRace, userInfo.id, userInfo.username]);
+
+    // Join room handler
+    const handleJoinRoom = useCallback(async (code: string) => {
+        try {
+            setError('');
+            const result = await joinRace({
+                code: code.toUpperCase(),
+                guestId: userInfo.id,
+                guestUsername: userInfo.username,
+            });
+            setRaceId(result.raceId);
+            setRoomCode(code.toUpperCase());
+            setCorpus(result.corpus);
+            setCurrentChar(result.corpus.charAt(0));
+            setIncomingChars(result.corpus.substring(1));
+            setIsHost(false);
+            setGameState('waiting');
+        } catch (e) {
+            setError(e instanceof Error ? e.message : 'Failed to join room');
+        }
+    }, [joinRace, userInfo.id, userInfo.username]);
+
+    // Start race handler (host only)
+    const handleStartRace = useCallback(async () => {
+        if (!raceId || !isHost) return;
+        try {
+            setError('');
+            await startCountdown({ raceId, userId: userInfo.id });
+        } catch (e) {
+            setError(e instanceof Error ? e.message : 'Failed to start race');
+        }
+    }, [raceId, isHost, startCountdown, userInfo.id]);
+
+    // Leave room handler
+    const handleLeaveRoom = useCallback(async () => {
+        if (raceId) {
+            await leaveRace({ raceId, userId: userInfo.id });
+        }
+        setGameState('lobby');
+        setRaceId(null);
+        setRoomCode('');
+        setIsHost(false);
+        setCorpus('');
+        setError('');
+    }, [raceId, leaveRace, userInfo.id]);
+
+    // Race again handler
+    const handleRaceAgain = useCallback(() => {
+        // Reset all state
+        setGameState('lobby');
+        setRaceId(null);
+        setRoomCode('');
+        setIsHost(false);
+        setCorpus('');
+        setLeftPadding(new Array(isSm ? 25 : 30).fill(' ').join(''));
+        setOutgoingChars('');
+        setIncorrectChar(false);
+        setCurrentChar('');
+        setIncomingChars('');
+        setCharCount(0);
+        setWpm(0);
+        setSeconds(30);
+        setStartTime(0);
+        setCountdown(3);
+        setError('');
+    }, [isSm]);
+
+    // Set corpus when race data loads (for host)
+    useEffect(() => {
+        if (race?.corpus && !corpus) {
+            setCorpus(race.corpus);
+            setCurrentChar(race.corpus.charAt(0));
+            setIncomingChars(race.corpus.substring(1));
+        }
+    }, [race?.corpus, corpus]);
+
+    // Get opponent info
+    const opponentUsername = useMemo(() => {
+        if (!race) return '';
+        return isHost ? race.guestUsername : race.hostUsername;
+    }, [race, isHost]);
+
+    const myProgress = useMemo(() => {
+        return raceProgress?.find(p => p.odId === userInfo.id);
+    }, [raceProgress, userInfo.id]);
+
+    const opponentProgress = useMemo(() => {
+        return raceProgress?.find(p => p.odId !== userInfo.id);
+    }, [raceProgress, userInfo.id]);
+
+    if (isLoading) {
+        return <TypingLoader message="Preparing multiplayer..." letters={['R', 'A', 'C', 'E']} />;
+    }
+
+    return (
+        <>
+            <Head>
+                <title>Multiplayer - Typer Racer</title>
+                <link rel="icon" href={tabIcon} />
+            </Head>
+            <ToggleButton />
+            <div className="flex items-center justify-center relative min-h-screen pt-8">
+                <div className="font-mono text-center max-w-3xl w-full px-4 mx-auto">
+                    {/* Error display */}
+                    {error && (
+                        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-100 rounded">
+                            {error}
+                        </div>
+                    )}
+
+                    {/* Lobby */}
+                    {gameState === 'lobby' && (
+                        <MultiplayerLobby
+                            onCreateRoom={handleCreateRoom}
+                            onJoinRoom={handleJoinRoom}
+                            onBack={() => router.push('/typer-racer')}
+                        />
+                    )}
+
+                    {/* Waiting Room */}
+                    {gameState === 'waiting' && (
+                        <WaitingRoom
+                            roomCode={roomCode}
+                            isHost={isHost}
+                            opponentUsername={opponentUsername}
+                            onStartRace={handleStartRace}
+                            onLeave={handleLeaveRoom}
+                        />
+                    )}
+
+                    {/* Countdown */}
+                    {gameState === 'countdown' && (
+                        <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50">
+                            <div className="text-9xl font-bold text-white animate-pulse">
+                                {countdown > 0 ? countdown : 'GO!'}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Racing */}
+                    {(gameState === 'racing' || gameState === 'countdown') && (
+                        <>
+                            <RaceProgress
+                                myProgress={{ charsTyped: charCount, wpm, username: userInfo.username }}
+                                opponentProgress={opponentProgress ? {
+                                    charsTyped: opponentProgress.charsTyped,
+                                    wpm: opponentProgress.wpm,
+                                    username: opponentUsername || 'Opponent',
+                                    disconnected: opponentProgress.disconnected,
+                                } : undefined}
+                                totalChars={corpus.length}
+                            />
+                            <div className="mb-4">
+                                <h3 className="text-center">WPM: {wpm} | Time: {seconds}s</h3>
+                            </div>
+                            <TypingBoard
+                                currentChar={currentChar}
+                                incomingChars={incomingChars}
+                                incorrectChar={incorrectChar}
+                                isSm={isSm}
+                                leftPadding={leftPadding}
+                                outgoingChars={outgoingChars}
+                            />
+                            {opponentProgress?.disconnected && (
+                                <div className="mt-4 p-2 bg-yellow-100 dark:bg-yellow-900 text-yellow-700 dark:text-yellow-100 rounded">
+                                    Opponent disconnected - continue for your score!
+                                </div>
+                            )}
+                        </>
+                    )}
+
+                    {/* Results */}
+                    {gameState === 'finished' && (
+                        <MultiplayerResults
+                            myWpm={myProgress?.wpm || wpm}
+                            opponentWpm={opponentProgress?.wpm || 0}
+                            myUsername={userInfo.username}
+                            opponentUsername={opponentUsername || 'Opponent'}
+                            opponentDisconnected={opponentProgress?.disconnected || false}
+                            onRaceAgain={handleRaceAgain}
+                            onLeave={() => router.push('/typer-racer')}
+                        />
+                    )}
+                </div>
+            </div>
+        </>
+    );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const { userId } = getAuth(context.req);
+    const user = userId ? await clerkClient.users.getUser(userId) : undefined;
+    const {
+        __clerk_ssr_state: {
+            // @ts-ignore
+            user: userInfo,
+        },
+    } = buildClerkProps(context.req, { user });
+
+    return { props: { userInfo } };
+};

--- a/src/pages/typer-racer.tsx
+++ b/src/pages/typer-racer.tsx
@@ -4,6 +4,7 @@ import TypingLoader from '@/components/TypingLoader';
 import { useTheme } from 'next-themes';
 import Head from 'next/head';
 import { useEffect, useMemo, useState, useRef } from 'react';
+import { useRouter } from 'next/router';
 import TypingBoard from './components/TypingBoard';
 import useDatabaseInfo from '../hooks/useDatabaseInfo';
 import useTypingGame from '../hooks/useTypingGame';
@@ -74,6 +75,15 @@ const LeaderboardButton = ({ onClick }: { onClick: () => void }) => (
     </button>
 );
 
+const MultiplayerButton = ({ onClick }: { onClick: () => void }) => (
+    <button
+        onClick={onClick}
+        className="mb-4 ml-2 border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 py-1 px-3 rounded-sm transition-colors"
+    >
+        Multiplayer
+    </button>
+);
+
 const TryAgainButton = ({ resetState }: { resetState: () => void }): JSX.Element | null => {
     const [mounted, setMounted] = useState(false);
 
@@ -102,6 +112,7 @@ const TryAgainButton = ({ resetState }: { resetState: () => void }): JSX.Element
 
 export default function TyperRacer() {
     const isSm = useIsSm();
+    const router = useRouter();
     const { isSignedIn, isLoaded, user } = useUser();
     const [isLoading, setIsLoading] = useState(true);
     const raceSpanEndRef = useRef<(() => void) | null>(null);
@@ -224,7 +235,10 @@ export default function TyperRacer() {
                                 </>
                             )}
                             {showLeaderboardButton && (
-                                <LeaderboardButton onClick={game.skipToResults} />
+                                <div className="flex justify-center">
+                                    <LeaderboardButton onClick={game.skipToResults} />
+                                    <MultiplayerButton onClick={() => router.push('/multiplayer')} />
+                                </div>
                             )}
                         </div>
                         {game.isGameOver && (

--- a/src/pages/typer-racer.tsx
+++ b/src/pages/typer-racer.tsx
@@ -237,7 +237,9 @@ export default function TyperRacer() {
                             {showLeaderboardButton && (
                                 <div className="flex justify-center">
                                     <LeaderboardButton onClick={game.skipToResults} />
-                                    <MultiplayerButton onClick={() => router.push('/multiplayer')} />
+                                    <MultiplayerButton
+                                        onClick={() => router.push('/multiplayer')}
+                                    />
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
## Summary
- Room-based matchmaking with 6-character codes
- Real-time opponent progress tracking via Convex subscriptions
- Synchronized countdown and race start
- Live WPM and progress display for both players
- Disconnect handling (opponent shows as DNF)

### New Components
- `MultiplayerLobby`: Create/join room UI
- `WaitingRoom`: Room code display, player list
- `RaceProgress`: Live progress bars for both players
- `MultiplayerResults`: Winner display and stats

### Backend (Convex)
- `races` table: room state, players, corpus
- `raceProgress` table: real-time player progress
- Mutations: createRace, joinRace, startCountdown, updateProgress, finishRace

## Test plan
- [ ] Can create a room and get a code
- [ ] Second player can join with code
- [ ] Both players see synchronized countdown
- [ ] Progress updates in real-time during race
- [ ] Winner is correctly determined
- [ ] Disconnect is handled gracefully